### PR TITLE
Adds separate code of conduct doc to follow standards

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,47 @@
+Contributor Code of Conduct
+---
+
+As contributors and maintainers of this project, and in the interest of
+fostering an open and welcoming community, we pledge to respect all people who
+contribute through reporting issues, posting feature requests, updating
+documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free
+experience for everyone, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal appearance,
+body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic
+  addresses, without explicit permission
+* Other unethical or unprofessional conduct
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+By adopting this Code of Conduct, project maintainers commit themselves to
+fairly and consistently applying these principles to every aspect of managing
+this project. Project maintainers who do not follow or enforce the Code of
+Conduct may be permanently removed from the project team.
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting a project maintainer. All complaints will be reviewed
+and investigated and will result in a response that is deemed necessary and
+appropriate to the circumstances. Maintainers are obligated to maintain
+confidentiality with regard to the reporter of an incident.
+
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+[version 1.3.0](https://www.contributor-covenant.org/version/1/3/0/code-of-conduct.html).
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,60 +2,14 @@ Contributing
 ---
 
 If you would like to get involved and contribute to this project, please read
-through this document first in order to understand our Code of Conduct,
-Process Guidelines, and the general Scope of the project.
+through the [Code of Conduct](CODE_OF_CONDUCT.md) first. Then, read through 
+this document to understand Process Guidelines, and the general Scope of the project.
 
 ---
 
 ## Maintainers
 
  * Sean Shookman | Data Scientist | sshookman@cars.com
-
-## Contributor Code of Conduct
-
-As contributors and maintainers of this project, and in the interest of
-fostering an open and welcoming community, we pledge to respect all people who
-contribute through reporting issues, posting feature requests, updating
-documentation, submitting pull requests or patches, and other activities.
-
-We are committed to making participation in this project a harassment-free
-experience for everyone, regardless of level of experience, gender, gender
-identity and expression, sexual orientation, disability, personal appearance,
-body size, race, ethnicity, age, religion, or nationality.
-
-Examples of unacceptable behavior by participants include:
-
-* The use of sexualized language or imagery
-* Personal attacks
-* Trolling or insulting/derogatory comments
-* Public or private harassment
-* Publishing other's private information, such as physical or electronic
-  addresses, without explicit permission
-* Other unethical or unprofessional conduct
-
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
-
-By adopting this Code of Conduct, project maintainers commit themselves to
-fairly and consistently applying these principles to every aspect of managing
-this project. Project maintainers who do not follow or enforce the Code of
-Conduct may be permanently removed from the project team.
-
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community.
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting a project maintainer. All complaints will be reviewed
-and investigated and will result in a response that is deemed necessary and
-appropriate to the circumstances. Maintainers are obligated to maintain
-confidentiality with regard to the reporter of an incident.
-
-
-This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
-[version 1.3.0](https://www.contributor-covenant.org/version/1/3/0/code-of-conduct.html).
 
 ## Project Scope
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <img src="https://www.cars.com/react-shop-webapp/static/cars-logo.c3ccfb95f1c14e7c071e1d3d8c44d28c.png"><br><br>
 </div>
 -->
-![Version](https://img.shields.io/badge/Version-0.1.1-green.svg?style=plastic)
+![Version](https://img.shields.io/badge/Version-0.1.2-green.svg?style=plastic)
 [![CircleCI token](https://img.shields.io/circleci/token/cb75132d9ffe340a42dd5deea2f0fff43eb61042/project/github/carsdotcom/skelebot/master.svg?style=plastic)](https://circleci.com/gh/carsdotcom/skelebot)
 
 # Skelebot <!--TODO: Replace this with LOGO/MASCOT -->
@@ -57,4 +57,4 @@ To get started using Skelebot you can follow the documentation found [here](http
 
 ## Contributing
 
-Anyone is welcome to make contributions to the project. If you would like to make a contribution, please read our [Contributor Code of Conduct](CONTRIBUTING.md).
+Anyone is welcome to make contributions to the project. If you would like to make a contribution, please read our [Contributor Guide](CONTRIBUTING.md).

--- a/skelebot.yaml
+++ b/skelebot.yaml
@@ -1,6 +1,6 @@
 name: skelebot
 description: ML Build Tool
-version: 0.1.1
+version: 0.1.2
 skelebotVersion: 0.1.0
 maintainer: Sean Shookman
 contact: sshookman@cars.com

--- a/skelebot/globals.py
+++ b/skelebot/globals.py
@@ -1,8 +1,9 @@
-VERSION = "0.1.1"
+VERSION = "0.1.2"
 IMAGE_VERSION = 0.1
 
 # Maps the Skelebot versions to image versions for compatability
 IMAGE_VERSION_MAP = {
+    "0.1.2": 0.1,
     "0.1.1": 0.1,
     "0.1.0": 0.1
 }


### PR DESCRIPTION
Adds separate code of conduct doc to follow standards outlined by GitHub. This will give the project the maximum 'community' profile score.

This Pull Request closes #5