### PR TITLE
Use colorama for cross-platform term colors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setup(
         "requests==2.22.0",
         "schema==0.7.0",
         "coverage",
-        "pytest"
+        "pytest",
+        "colorama"
     ],
     entry_points={
         'console_scripts': [

--- a/skelebot.yaml
+++ b/skelebot.yaml
@@ -12,6 +12,7 @@ dependencies:
 - coverage
 - pytest
 - schema==0.7.0
+- colorama==0.4.1
 ignores:
 - '**/*.zip'
 - '**/*.RData'

--- a/skelebot/common.py
+++ b/skelebot/common.py
@@ -1,16 +1,19 @@
 """Common Global Variables"""
 
+import colorama
 import pkg_resources
 
 VERSION = pkg_resources.get_distribution("skelebot").version
 DESCRIPTION = """
-\033[1m{project}\033[0m
-{desc}
+{bold}{{project}}{reset}
+{{desc}}
 -----------------------------------
-Version: {pVersion}
-Environment: {env}
-Skelebot Version: {version}
------------------------------------"""
+Version: {{pVersion}}
+Environment: {{env}}
+Skelebot Version: {{version}}
+-----------------------------------""".format(
+    bold=colorama.Style.BRIGHT, reset=colorama.Style.RESET_ALL
+)
 SKELEBOT_HOME = "~/.skelebot"
 PLUGINS_HOME = "{home}/plugins".format(home=SKELEBOT_HOME)
 

--- a/skelebot/skelebot.py
+++ b/skelebot/skelebot.py
@@ -1,13 +1,21 @@
 """Skelebot - Machine Learning Project Management Tool"""
 
 import sys
-from schema import SchemaError
-from .systems.parsing import skeleParser
-from .systems.generators import yaml
-from .systems.execution import executor
 
-SCHEMA_ERROR = "\u001b[0m\u001b[31mERROR\u001b[0m | skelebot.yaml | {}"
-ERROR = "\u001b[0m\u001b[31mERROR\u001b[0m | {}"
+import colorama
+from schema import SchemaError
+
+from .systems.execution import executor
+from .systems.generators import yaml
+from .systems.parsing import skeleParser
+
+SCHEMA_ERROR = "{reset}{red}ERROR{reset} | skelebot.yaml | {{}}".format(
+    reset=colorama.Style.RESET_ALL, red=colorama.Fore.RED
+)
+ERROR = "{reset}{red}ERROR{reset} | {{}}".format(
+    reset=colorama.Style.RESET_ALL, red=colorama.Fore.RED
+)
+
 
 def main():
     """
@@ -22,9 +30,6 @@ def main():
         executor.execute(config, parser)
     except SchemaError as error:
         print(SCHEMA_ERROR.format(error))
-        sys.exit(1)
-    except RuntimeError as error:
-        print(ERROR.format(error))
         sys.exit(1)
 
 def get_env():


### PR DESCRIPTION
## What

Make terminal colors work consistently in different platforms

## Why

Closes #73 

## Additional notes:

`colorama` requirement added

