### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -35,7 +35,7 @@ If you do not have proper access on the machine you are using, Skelebot can be i
 Skelebot developers should first install the package with the additional `dev` dependencies and then test their installation:
 
 ```
-> pip install .[dev]
+> pip install '.[dev]'
 > pytest .
 ```
 


### PR DESCRIPTION
## Summary
- Quote `pip install` examples that include extras.

## Why
- Shells such as zsh can expand unquoted bracket expressions before `pip` receives them.

## Scope
- Files changed:
- `docs/installing.md`
- This does not change dependencies or runtime behavior.

## Testing
- `git diff --check`

## Maintainer Fit
- Small install-command correctness fix.
- Duplicate PR search terms checked: `quote pip extras`, `quote optional dependency`, `zsh pip install extras`, `pip extras install examples`